### PR TITLE
Make game loop back to first level after beating last level

### DIFF
--- a/Assets/Scripts/Configuration.cs
+++ b/Assets/Scripts/Configuration.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO;
 using static ShootAR.Spawner;
 using UnityEngine;
+using System.Xml;
 
 namespace ShootAR {
 	/// <summary>
@@ -29,6 +30,21 @@ namespace ShootAR {
 				spawnPatternSlot = value;
 				UnsavedChanges = true;
 
+				// Get how many levels are in the spawn pattern:
+				int numberOfLevels = 0;
+				using (
+					XmlReader element = XmlReader.Create(Configuration.Instance.SpawnPatternFile)
+				) {
+					element.MoveToContent();
+					element.ReadToDescendant("level");
+					do {
+						numberOfLevels++;
+					} while (element.ReadToNextSibling("level"));
+
+					NumberOfLevels = numberOfLevels;
+				}
+				// ---
+
 				OnSlotChanged?.Invoke();
 			}
 		}
@@ -43,6 +59,9 @@ namespace ShootAR {
 		public string SpawnPatternFile {
 			get => $"{patternsDir.FullName}/{SpawnPattern}.xml";
 		}
+
+		/// <summary>The total number of levels defined in the selected pattern file.</summary>
+		public int NumberOfLevels { get; private set; }
 
 		private bool soundMuted = false;
 

--- a/Assets/Scripts/Game/GameManager.cs
+++ b/Assets/Scripts/Game/GameManager.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.UI;
 using System.Collections;
+using System.Xml;
 
 namespace ShootAR
 {
@@ -221,9 +222,28 @@ namespace ShootAR
 			Debug.Log($"Advancing to level {gameState.Level}");
 #endif
 
+			// Get how many levels are in the spawn pattern:
+			int numberOfLevels = 0;
+			using (XmlReader element = XmlReader.Create(Configuration.Instance.SpawnPatternFile)) {
+				element.MoveToContent();
+				element.ReadToDescendant("level");
+				do {
+					numberOfLevels++;
+				} while (element.ReadToNextSibling("level"));
+			}
+
+			int roundedLevel; // round index translated to level in the spawn file
+			if (gameState.Level > numberOfLevels
+				&& gameState.Level / numberOfLevels > 0)
+			{
+				roundedLevel = gameState.Level / numberOfLevels;
+			}
+			else
+				roundedLevel = gameState.Level;
+
 			// Configuring spawners
 			Stack<Spawner.SpawnConfig>[] patterns
-				= Spawner.ParseSpawnPattern(Configuration.Instance.SpawnPatternFile);
+				= Spawner.ParseSpawnPattern(Configuration.Instance.SpawnPatternFile, roundedLevel);
 
 			Spawner.SpawnerFactory(patterns, 0, ref spawnerGroups, ref stashedSpawners);
 

--- a/Assets/Scripts/Game/GameManager.cs
+++ b/Assets/Scripts/Game/GameManager.cs
@@ -262,18 +262,18 @@ namespace ShootAR
 			/* Player should always have enough ammo to play the next
 			 * round. If they already have more than enough, they get
 			 * points. */
-			ulong difference = (ulong)(player.Ammo - totalEnemies);
+			int difference = player.Ammo - totalEnemies;
 			if (difference > 0)
-				scoreManager.AddScore(difference * 10);
+				scoreManager.AddScore((ulong)difference * 10);
 			else if (difference < 0) {
 				/* If it is before the 1st round, give player more bullets
 				 * so they are allowed to miss shots. */
 				const float bonusBullets = 0.55f;
 				if (gameState.Level == 1) {
-					difference *=  (ulong)bonusBullets;
+					difference = (int)(difference * bonusBullets);
 				}
 
-				player.Ammo += (difference < int.MaxValue) ? -(int)difference : int.MaxValue;
+				player.Ammo += -difference;
 			}
 
 			gameState.RoundWon = false;

--- a/Assets/Scripts/Game/GameManager.cs
+++ b/Assets/Scripts/Game/GameManager.cs
@@ -5,7 +5,6 @@ using System.IO;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.UI;
-using System.Collections;
 using System.Xml;
 
 namespace ShootAR
@@ -222,24 +221,10 @@ namespace ShootAR
 			Debug.Log($"Advancing to level {gameState.Level}");
 #endif
 
-			// Get how many levels are in the spawn pattern:
-			int numberOfLevels = 0;
-			using (XmlReader element = XmlReader.Create(Configuration.Instance.SpawnPatternFile)) {
-				element.MoveToContent();
-				element.ReadToDescendant("level");
-				do {
-					numberOfLevels++;
-				} while (element.ReadToNextSibling("level"));
-			}
-
-			int roundedLevel; // round index translated to level in the spawn file
-			if (gameState.Level > numberOfLevels
-				&& gameState.Level / numberOfLevels > 0)
-			{
-				roundedLevel = gameState.Level / numberOfLevels;
-			}
-			else
-				roundedLevel = gameState.Level;
+			/* If the current level exceeds the total number of defined levels,
+			 * translate the index to the equivalent level in pattern file. */
+			int l = gameState.Level % Configuration.Instance.NumberOfLevels;
+			int roundedLevel = l == 0 ? Configuration.Instance.NumberOfLevels : l;
 
 			// Configuring spawners
 			Dictionary<Type, Stack<Spawner.SpawnConfig>> patterns

--- a/Assets/Scripts/Game/GameManager.cs
+++ b/Assets/Scripts/Game/GameManager.cs
@@ -242,10 +242,10 @@ namespace ShootAR
 				roundedLevel = gameState.Level;
 
 			// Configuring spawners
-			Stack<Spawner.SpawnConfig>[] patterns
+			Dictionary<Type, Stack<Spawner.SpawnConfig>> patterns
 				= Spawner.ParseSpawnPattern(Configuration.Instance.SpawnPatternFile, roundedLevel);
 
-			Spawner.SpawnerFactory(patterns, 0, ref spawnerGroups, ref stashedSpawners);
+			Spawner.SpawnerFactory(patterns, ref spawnerGroups, ref stashedSpawners);
 
 			int totalEnemies = 0;
 			foreach (var group in spawnerGroups) {

--- a/Assets/Scripts/Game/Spawner.cs
+++ b/Assets/Scripts/Game/Spawner.cs
@@ -319,16 +319,18 @@ namespace ShootAR
 			 * the same <spawnable> node. */
 
 			while (!doneParsingForCurrentLevel) {
-				if (!(xmlPattern?.Read() ?? false)) {
+				if (!(xmlPattern?.Read() ?? false)) { //< Moving to next element happens here.
 					xmlPattern = XmlReader.Create(spawnPatternFilePath);
 					xmlPattern.MoveToContent();
-				}
 
-				// skip to wanted level
-				if (level > 1) {
+					// skip to wanted level
 					xmlPattern.ReadToDescendant("level");
-					for (int i = 1; i < level; i++) {
-						xmlPattern.Skip();
+					for (int i = 1; level > i; i++) {
+						if (!xmlPattern.ReadToNextSibling("level")) {
+							throw new UnityException(
+								"Not enough levels in spawn pattern."
+							);
+						}
 					}
 				}
 
@@ -421,7 +423,7 @@ namespace ShootAR
 				}
 			}
 
-			xmlPattern.Close();
+			xmlPattern.Dispose();
 
 			Stack<SpawnConfig>[] extractedPatterns = new Stack<SpawnConfig>[groupsByType.Count];
 			groupsByType.Values.CopyTo(extractedPatterns, 0);

--- a/Assets/Tests/PatternsFileTests.cs
+++ b/Assets/Tests/PatternsFileTests.cs
@@ -16,7 +16,7 @@ public class PatternsFileTests : PatternsTestBase
 		LocalFiles.CopyResourceToPersistentData(patternFileBasename, patternFile);
 
 		Assert.That(File.Exists(targetFile));
-		File.Delete(patternFile);
+		File.Delete(targetFile);
 	}
 
 	[Test]

--- a/Assets/Tests/TestTools.cs
+++ b/Assets/Tests/TestTools.cs
@@ -217,6 +217,12 @@ namespace ShootAR.TestTools
 			if (File.Exists(file))
 				File.Delete(file);
 
+			string highscoreFile = Path.Combine(
+				Application.persistentDataPath, Configuration.HIGHSCORES_DIR,
+				PATTERN_FILE
+			);
+			if (File.Exists(highscoreFile)) File.Delete(highscoreFile);
+
 			Assert.That(
 				!File.Exists(file),
 				"The file should be deleted when the test ends."

--- a/Assets/Tests/TestTools.cs
+++ b/Assets/Tests/TestTools.cs
@@ -199,6 +199,11 @@ namespace ShootAR.TestTools
 				writer.Write(1); // one string in file
 				writer.Write(PATTERN_FILE.TrimEnd(".xml".ToCharArray()));
 			}
+
+			// Make sure the patterns directory exists.
+			DirectoryInfo patternsDir = new DirectoryInfo(Path.Combine(
+				Application.persistentDataPath, Configuration.PATTERNS_DIR));
+			if (!patternsDir.Exists) patternsDir.Create();
 		}
 
 		[TearDown]


### PR DESCRIPTION
After beating the last level defined in the spawn pattern file and the game tries to go to the next level, the number of the next round exceeds the number of levels defined in the file. This patch fixes the game to loop back to the top of the pattern file, and know how to map any round to a level in the file.